### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
         "react-i18next": "^13.5.0",
         "react-redux": "^9.0.4",
         "react-syntax-highlighter": "^15.5.0",
-        "vite": "^5.2.12"
+        "vite": "^5.2.12",
+        "@vitejs/plugin-react": "^2.0.0"
     },
     "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -53,13 +54,14 @@
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "laravel-vite-plugin": "^1.0.4",
+        "laravel-vite-plugin": "^0.6.0",
         "npm-check-updates": "^16.14.11",
         "prettier": "^3.1.1",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.69.5",
         "sass-loader": "^13.x",
-        "simple-git-hooks": "^2.9.0"
+        "simple-git-hooks": "^2.9.0",
+        "vite": "^3.0.2"
     },
     "engines": {
         "node": "20.x"

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,32 +1,11 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
-import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  server: {
-    host: '0.0.0.0',
-    hmr: {
-      host: 'localhost',
-    },
-  },
-  plugins: [
-    laravel({
-      input: [
-        'resources/js/app.js',
-        'resources/js/custom.js',
-        'resources/js/hljs.js',
-        'resources/js/editor.js',
-        'resources/sass/app.scss',
-        'resources/sass/_activity_chart.scss',
-        'resources/sass/_custom.scss',
-      ],
-      refresh: true,
-    }),
-    react(),
-
-  ],
-  build: {
-    outDir: 'public/build',
-    emptyOutDir: false,
-  },
+    plugins: [
+        laravel({
+            input: ['resources/css/app.css', 'resources/js/app.js'],
+            refresh: true,
+        }),
+    ],
 });


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-122715` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
